### PR TITLE
SQLi Escape Parameter

### DIFF
--- a/connectors/sql.php.mysqli
+++ b/connectors/sql.php.mysqli
@@ -7,7 +7,8 @@
 $SQL_ENGINE="MySQLi";
 
 function sql_escape($str){
-	return mysqli_real_escape_string($str);	
+	global $db;
+	return mysqli_real_escape_string($db,$str);
 }
 
 function sql_get_db($dbhost,$dbsource,$dbuser,$dbpass){

--- a/connectors/sql.php.mysqli
+++ b/connectors/sql.php.mysqli
@@ -69,5 +69,3 @@ echo sql_affected_rows($db)." rows affected <br>";
 
 */
 
-
-?>


### PR DESCRIPTION
mysqli_real_escape_string has a different parameter order than mysql_real_escape_string. This makes the $link parameter mandatory.